### PR TITLE
Make Args Serializable

### DIFF
--- a/core/src/main/scala/com/quantifind/sumac/Args.scala
+++ b/core/src/main/scala/com/quantifind/sumac/Args.scala
@@ -2,11 +2,13 @@ package com.quantifind.sumac
 
 import collection._
 
-trait Args extends ExternalConfig {
+trait Args extends ExternalConfig with Serializable {
   def getArgs(argPrefix:String): Traversable[ArgAssignable]
 
+  @transient
   lazy val parser = ArgumentParser(getArgs(""))
   @Ignore
+  @transient
   var validationFunctions: Seq[() => Unit] = Seq()
 
   def parse(args: Array[String]) {

--- a/core/src/test/scala/com/quantifind/sumac/FieldArgsTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/FieldArgsTest.scala
@@ -4,6 +4,7 @@ import types.{SelectInput,MultiSelectInput}
 import org.scalatest.FunSuite
 import org.scalatest.matchers.ShouldMatchers
 import java.lang.reflect.Type
+import java.io.{ObjectInputStream, ByteArrayInputStream, ObjectOutputStream, ByteArrayOutputStream}
 
 /**
  *
@@ -300,6 +301,19 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     args.x should be (91)
     args.firstSet.x should be (-32)
     args.secondSet.x should be (11)
+  }
+
+  test("args are serializable") {
+    val args = new SomeArgs()
+    args.parse(Array("--x", "1", "--y", "test"))
+    val out = new ByteArrayOutputStream()
+    new ObjectOutputStream(out).writeObject(args)
+    out.close()
+    val in = new ByteArrayInputStream(out.toByteArray)
+    val deserializedArgs = new ObjectInputStream(in).readObject().asInstanceOf[SomeArgs]
+    in.close()
+    deserializedArgs.x should be (1)
+    deserializedArgs.y should be ("test")
   }
 
 }


### PR DESCRIPTION
This commit makes argument classes Serializable to allow their fields to referenced inside of Spark UDFs. 
