### PR TITLE
add a way for annotation validation functions to update the arg value

### DIFF
--- a/core/src/main/scala/com/quantifind/sumac/FieldArgs.scala
+++ b/core/src/main/scala/com/quantifind/sumac/FieldArgs.scala
@@ -65,16 +65,17 @@ trait FieldArgs extends Args {
     field: FieldArgAssignable,
     default: Any,
     annot: Annotation,
-    check: (Any, Any, Annotation, String) => Unit
+    check: (Any, Any, Annotation, String, ArgAssignable) => Unit
   ) extends (() => Unit) {
     def apply() {
-      check(default, field.getCurrentValue, annot, field.getName)
+      check(default, field.getCurrentValue, annot, field.getName, field)
     }
     override def toString() = "annotation check of " + field.getName
   }
 
   @transient
-  private[sumac] val annotationValidationFunctions = mutable.Map[Class[_ <: Annotation], (Any,Any, Annotation, String) => Unit]()
+  private[sumac] val annotationValidationFunctions =
+    mutable.Map[Class[_ <: Annotation], (Any,Any, Annotation, String, ArgAssignable) => Unit]()
 
 
   /**
@@ -89,9 +90,16 @@ trait FieldArgs extends Args {
    *                           first argument is the default value of the argument, the second is the current value,
    *                           the third is the annotation, and the fourth is the name of the argument (for error msgs).
    */
-  def registerAnnotationValidation(annotation: Class[_ <: Annotation])(validationFunction: (Any,Any, Annotation, String) => Unit) {
+  def registerAnnotationValidationUpdate(annotation: Class[_ <: Annotation])(validationFunction: (Any,Any, Annotation, String, ArgAssignable) => Unit) {
     annotationValidationFunctions += annotation -> validationFunction
   }
+
+  def registerAnnotationValidation(annotation: Class[_ <: Annotation])(validationFunction: (Any,Any, Annotation, String) => Unit) {
+    registerAnnotationValidationUpdate(annotation){(a:Any,b:Any,c:Annotation,d:String,e:ArgAssignable) => validationFunction(a,b,c,d)}
+  }
+
+
+
 
   {
     //some built-in annotation validations

--- a/core/src/test/scala/com/quantifind/sumac/ValidationSuite.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ValidationSuite.scala
@@ -117,6 +117,13 @@ class ValidationSuite extends FunSuite with ShouldMatchers {
     val a2 = new UnregisteredAnnotationArgs()
     a2.parse(Map("x" -> "7"))
     a2.x should be (7)
+
+    val a3 = new UserDefinedAnnotationUpdateArgs()
+    a3.parse(Map("x" -> "17"))
+    a3.x should be (3)
+
+    a3.parse(Map("x" -> "4"))
+    a3.x should be (4)
   }
 
   test("multi-annotation") {
@@ -209,6 +216,16 @@ class UserDefinedAnnotationArgs extends FieldArgs {
   registerAnnotationValidation(classOf[ThreeOrFour]){(_, value, _, name) =>
     if (value != 3 && value != 4) {
       throw new ArgException(name + " must be 3 or 4")
+    }
+  }
+}
+
+class UserDefinedAnnotationUpdateArgs extends FieldArgs {
+  @ThreeOrFour
+  var x: Int = _
+  registerAnnotationValidationUpdate(classOf[ThreeOrFour]){(_, value, _, name, holder) =>
+    if (value != 3 && value !=4) {
+      holder.setValue(3)
     }
   }
 }


### PR DESCRIPTION
I want to be able to right annotation validation functions that update the values.  (Before this, basically the only thing you could do in an annotation validation function was throw an exception.)
