### PR TITLE
Update for Scala 2.12 & bump version 0.4.

### DIFF
--- a/core/src/test/scala/com/quantifind/sumac/ArgAppTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ArgAppTest.scala
@@ -1,9 +1,9 @@
 package com.quantifind.sumac
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-class ArgAppTest extends FunSuite with ShouldMatchers {
+class ArgAppTest extends FunSuite with Matchers {
 
   test("getArgumentClass") {
     val m = new MyApp()
@@ -28,7 +28,7 @@ class MyArgs extends FieldArgs {
   var b: Int = 0
 }
 
-class MyApp extends Dummy with ArgApp[MyArgs] with ShouldMatchers {
+class MyApp extends Dummy with ArgApp[MyArgs] with Matchers {
   def main(args: MyArgs) {
     args.a should be ("hello")
     args.b should be (17)
@@ -42,7 +42,7 @@ trait NestedArgMain extends ArgMain[MyArgs] {
   def blah(x: Int) = x + 5
 }
 
-class MyNestedArgApp extends NestedArgMain with ShouldMatchers {
+class MyNestedArgApp extends NestedArgMain with Matchers {
   def main(args: MyArgs) {
     args.a should be ("byebye")
     args.b should be (3)

--- a/core/src/test/scala/com/quantifind/sumac/ArgBuilderTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ArgBuilderTest.scala
@@ -1,10 +1,10 @@
 package com.quantifind.sumac
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import java.io._
 
-class ArgBuilderTest extends FunSuite with ShouldMatchers {
+class ArgBuilderTest extends FunSuite with Matchers {
 
   val nullOutput = new PrintStream(new OutputStream {
     def write(p1: Int) {}

--- a/core/src/test/scala/com/quantifind/sumac/ArgumentParserTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ArgumentParserTest.scala
@@ -1,10 +1,10 @@
 package com.quantifind.sumac
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import scala.collection._
 
-class ArgumentParserTest extends FunSuite with ShouldMatchers {
+class ArgumentParserTest extends FunSuite with Matchers {
 
   test("parse") {
     val c = SimpleClass("a", 0, 1.4, 2)

--- a/core/src/test/scala/com/quantifind/sumac/ExternalConfigTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ExternalConfigTest.scala
@@ -2,9 +2,9 @@ package com.quantifind.sumac
 
 import org.scalatest.FunSuite
 import collection._
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-class ExternalConfigTest extends FunSuite with ShouldMatchers {
+class ExternalConfigTest extends FunSuite with Matchers {
   test("modifying args"){
     val args = new ExtArgs() with DefaultNumeroUno
     args.parse(Array("--x", "5", "--y", "hi there"))

--- a/core/src/test/scala/com/quantifind/sumac/FieldArgsTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/FieldArgsTest.scala
@@ -2,14 +2,14 @@ package com.quantifind.sumac
 
 import types.{SelectInput,MultiSelectInput}
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import java.lang.reflect.Type
 
 /**
  *
  */
 
-class FieldArgsTest extends FunSuite with ShouldMatchers {
+class FieldArgsTest extends FunSuite with Matchers {
 
   test("parseStrings") {
     val o = new StringHolder(null, null) with FieldArgs
@@ -44,17 +44,17 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
 
   test("help message") {
     val o = new StringHolder(null, null) with FieldArgs
-    val exc1 = evaluating {o.parse(Array("--xyz", "hello"))} should produce [ArgException]
+    val exc1 = intercept[ArgException]{o.parse(Array("--xyz", "hello"))}
     //the format is still ugly, but at least there is some info there
     "\\-\\-name\\s.*String".r.findFirstIn(exc1.getMessage()) should be ('defined)
     "\\-\\-comment\\s.*String".r.findFirstIn(exc1.getMessage()) should be ('defined)
 
     val o2 = new MixedTypes(null, 0) with FieldArgs
-    val exc2 = evaluating {o2.parse(Array("--foo", "bar"))} should produce [ArgException]
+    val exc2 = intercept[ArgException] {o2.parse(Array("--foo", "bar"))}
     "\\-\\-name\\s.*String".r findFirstIn(exc2.getMessage) should be ('defined)
     "\\-\\-count\\s.*[Ii]nt".r findFirstIn(exc2.getMessage) should be ('defined)  //java or scala types, I'll take either for now
 
-    val exc3 = evaluating {o2.parse(Array("--count", "ooga"))} should produce [ArgException]
+    val exc3 = intercept[ArgException] {o2.parse(Array("--count", "ooga"))}
     //this message really should be much better.  (a) the number format exception should come first and (b) should indicate that it was while processing the "count" argument
     "\\-\\-name\\s.*String".r findFirstIn(exc3.getMessage) should be ('defined)
     "\\-\\-count\\s.*[Ii]nt".r findFirstIn(exc3.getMessage) should be ('defined)  //java or scala types, I'll take either for now
@@ -70,12 +70,12 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     o.name should be ("blah")
 
     //it will throw an exception if we pass in an argument for a field that it didn't know what to do with
-    val exc = evaluating {o.parse(Array("--funky", ""))} should produce [ArgException]
+    val exc = intercept[ArgException] {o.parse(Array("--funky", ""))}
     exc.getMessage should include ("unknown option funky")
 
     //on the other hand, FieldArgsExceptionOnUnparseable will throw an exception no matter what we do
     val o2 = new SpecialTypes("", null) with FieldArgsExceptionOnUnparseable
-    val exc2 = evaluating {o2.parse(Array("--name", "blah"))} should produce [ArgException]
+    val exc2 = intercept[ArgException] {o2.parse(Array("--name", "blah"))}
     exc2.getMessage should include ("type")
     exc2.getMessage should include ("MyFunkyType")
   }
@@ -84,7 +84,7 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
   test("good error msg") {
     val o = new MixedTypes("", 0) with FieldArgs
 
-    val exc1 = evaluating {o.parse(Array("--count", "hi"))} should produce [ArgException]
+    val exc1 = intercept[ArgException] {o.parse(Array("--count", "hi"))}
     //don't actually need the message to look *exactly* like this, but extremely useful for it to at least say what it was trying to parse
     exc1.getMessage should startWith ("""Error parsing "hi" into field "count" (type = int)""")
   }
@@ -98,7 +98,7 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
 
   test("help") {
     val s = new IgnoredArgs()
-    val exc = evaluating {s.parse(Array("--help"))} should produce [ArgException]
+    val exc = intercept[ArgException] {s.parse(Array("--help"))}
     """unknown option""".r findFirstIn (exc.getMessage) should be ('empty)
     """\-\-x\s.*[Ii]nt""".r findFirstIn(exc.getMessage) should be ('defined)
   }
@@ -112,7 +112,7 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     System.identityHashCode(s.select) should be (id)
     s.select.options should be (Set("a", "b", "c"))
 
-    evaluating {s.parse(Array("--select", "q"))} should produce [ArgException]
+    intercept[ArgException] {s.parse(Array("--select", "q"))}
   }
 
   test("selectInput order") {
@@ -129,7 +129,7 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     System.identityHashCode(s.select) should be (id)
     s.select.options.toList should be (orderedChoices)
 
-    evaluating {s.parse(Array("--select", "q"))} should produce [ArgException]
+    intercept[ArgException] {s.parse(Array("--select", "q"))}
   }
 
   test("multiSelectInput") {
@@ -144,10 +144,9 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     s.parse(Array("--multiSelect", "b,c"))
     s.multiSelect.value should be (Set("b", "c"))
 
-    evaluating {s.parse(Array("--multiSelect", "q"))} should produce [ArgException]
-    evaluating {s.parse(Array("--multiSelect", "b,q"))} should produce [ArgException]
-    evaluating {s.parse(Array("--multiSelect", "q,b"))} should produce [ArgException]
-
+    intercept[ArgException] {s.parse(Array("--multiSelect", "q"))}
+    intercept[ArgException] {s.parse(Array("--multiSelect", "b,q"))}
+    intercept[ArgException] {s.parse(Array("--multiSelect", "q,b"))}
   }
 
   test("exclude scala helper fields") {
@@ -195,8 +194,8 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     c.y should be (181)
     c.z should be (1.81)
 
-    evaluating {c.parse(Array("--x", "17"))} should produce [ArgException]
-    evaluating {c.parse(Array("--z", "1"))} should produce [ArgException]
+    intercept[ArgException] {c.parse(Array("--x", "17"))}
+    intercept[ArgException] {c.parse(Array("--z", "1"))}
   }
 
 
@@ -220,7 +219,7 @@ class FieldArgsTest extends FunSuite with ShouldMatchers {
     c.y should be ("blah")
     c.z should be (134)
 
-    evaluating {c.parse(Array("--z", "0"))} should produce [Exception]
+    intercept[Exception] {c.parse(Array("--z", "0"))}
   }
 
   test("private fields ignored") {

--- a/core/src/test/scala/com/quantifind/sumac/ParserTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/ParserTest.scala
@@ -1,13 +1,13 @@
 package com.quantifind.sumac
 
 import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
 /**
  *
  */
 
-class ParserTest extends FunSuite with ShouldMatchers {
+class ParserTest extends FunSuite with Matchers {
 
   test("SimpleParser") {
     StringParser.parse("ooga") should be ("ooga")

--- a/core/src/test/scala/com/quantifind/sumac/PropertiesConfigTest.scala
+++ b/core/src/test/scala/com/quantifind/sumac/PropertiesConfigTest.scala
@@ -3,9 +3,9 @@ package com.quantifind.sumac
 import org.scalatest.FunSuite
 import java.io.{PrintWriter, File}
 import java.util.Properties
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 
-class PropertiesConfigTest extends FunSuite with ShouldMatchers {
+class PropertiesConfigTest extends FunSuite with Matchers {
 
   val testOutDir = new File("test_output/" + getClass.getSimpleName)
   testOutDir.mkdirs()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,11 +3,11 @@ import Keys._
 
 object SumacBuild extends Build {
   lazy val core = Project("core", file("core"), settings = coreSettings)
-  lazy val zk = Project("zk", file("zk"), settings = zkSettings) dependsOn(core)
+  //lazy val zk = Project("zk", file("zk"), settings = zkSettings) dependsOn(core)
 
   def sharedSettings = Defaults.defaultSettings ++ Seq(
-    version := "0.2-SNAPSHOT",
-    scalaVersion := "2.9.3",
+    version := "0.4-SNAPSHOT",
+    scalaVersion := "2.12.8",
     organization := "com.quantifind",
     scalacOptions := Seq("-deprecation", "-unchecked", "-optimize"), 
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
@@ -20,7 +20,7 @@ object SumacBuild extends Build {
       "JBoss Repository" at "http://repository.jboss.org/nexus/content/repositories/releases/"
     ),
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.5" % "test"
     ),
 
     // Publishing configuration
@@ -79,7 +79,7 @@ object SumacBuild extends Build {
       "Twitter Repo" at "http://maven.twttr.com/"
     ),
     libraryDependencies ++= Seq(
-      "com.twitter"   % "util-zk"   % "5.3.10"
+      "com.twitter"  %% "util-zk"   % "18.12.0"
     )
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,5 @@
 #Project properties
 project.organization=com.quantifind
 project.name=Sumac
-project.version=0.1
-sbt.version=0.12.2
+project.version=0.4
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/zk/src/test/scala/com/quantifind/sumac/ZkArgsTest.scala
+++ b/zk/src/test/scala/com/quantifind/sumac/ZkArgsTest.scala
@@ -2,13 +2,13 @@ package com.quantifind.sumac
 
 import org.scalatest.{Tag, FunSuite}
 import com.twitter.conversions.time._
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers
 import com.twitter.util.JavaTimer
 import java.io.{FileInputStream, File}
 import java.util.Properties
 
 
-class ZkArgsTest extends FunSuite with ShouldMatchers {
+class ZkArgsTest extends FunSuite with Matchers {
 
   val runZkTests = false
   val zkTestHost = "localhost:2181"


### PR DESCRIPTION
This is a minimal update to build sumac w/ 2.12.  The core module
compiles and passes tests.  I did not migrate the zk module (code still
there, just commented out of build).

This also updated the version of sbt & scalatest.

I have not made any attempt to cross-compile here.

I chose to bump the version to 0.4-SNAPSHOT, as I figure we could
continue to maintain < 2.12 on the 0.3 line, if there is a need.